### PR TITLE
feat: add tags field to rooms for grouping functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, responsive meeting room booking application built with Next.js 15, fea
 - **Room-specific hours** - Custom operating hours for each room
 - **Capacity and location** information display
 - **Room status management** - Unavailable rooms prevent new bookings while showing existing ones
+- **Room tagging system** - Categorize rooms with tags for easy identification and grouping
 
 ### 📅 Booking System
 - **30-minute time slots** with visual availability indicators
@@ -67,6 +68,7 @@ Before running this application, you'll need:
    - `endTime` (Number) - Closing time in seconds from midnight (default: 64800 = 6:00 PM)
    - `maxMeetingHours` (Number) - Maximum meeting duration in hours (optional - overrides global setting)
    - `image` (Attachment) - Optional room photos
+   - `tags` (Multiple select) - Optional tags for grouping rooms (e.g., "Conference", "Video Call", "Large", "Small", "Quiet", "Whiteboard")
 
 4. **Create the Bookings table** with these fields:
    - `user` (Single line text) - Slack user ID
@@ -89,6 +91,13 @@ Before running this application, you'll need:
 - **Supports decimal values** for precise duration limits (e.g., `1.5` for 90 minutes, `0.5` for 30 minutes)
 - Example: Set `maxMeetingHours` to `2` for a small meeting room that should only allow 2-hour meetings
 - Example: Set `maxMeetingHours` to `1.5` for a room that should only allow 90-minute meetings
+
+**Note on Room Tags**: 
+- The `tags` field uses Airtable's "Multiple Select" type for easy room categorization
+- Tags are displayed as styled badges on room cards for quick visual identification
+- Suggested tags: "Conference", "Video Call", "Large", "Small", "Quiet", "Whiteboard", "Projector", "Training"
+- Tags are optional - rooms without tags will display normally
+- You can customize the available tag options in your Airtable base settings
 
 ### 2. Slack App Configuration
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Before running this application, you'll need:
 - Example: Set `maxMeetingHours` to `2` for a small meeting room that should only allow 2-hour meetings
 - Example: Set `maxMeetingHours` to `1.5` for a room that should only allow 90-minute meetings
 
-**Note on Room Tags**: 
 - The `tags` field uses Airtable's "Multiple Select" type for easy room categorization
 - Tags are displayed as styled badges on room cards for quick visual identification
 - Suggested tags: "Conference", "Video Call", "Large", "Small", "Quiet", "Whiteboard", "Projector", "Training"

--- a/app/components/RoomCard.tsx
+++ b/app/components/RoomCard.tsx
@@ -196,6 +196,20 @@ export function RoomCard({ room, bookings }: RoomCardProps) {
           )}
         </div>
 
+        {/* Room Tags */}
+        {room.tags && room.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {room.tags.map((tag, index) => (
+              <span
+                key={index}
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Current Booking */}
         {currentBooking && (
           <div className="bg-orange-50 border-l-4 border-orange-400 p-4 mb-4 rounded-r-lg">

--- a/app/components/__tests__/RoomCard.test.tsx
+++ b/app/components/__tests__/RoomCard.test.tsx
@@ -280,4 +280,43 @@ describe('RoomCard', () => {
     expect(screen.getByText('20')).toBeInTheDocument()
     expect(screen.getByText('people')).toBeInTheDocument()
   })
+
+  it('should render room tags when provided', () => {
+    const roomWithTags = {
+      ...mockRoom,
+      tags: ['Conference', 'Video Call', 'Large'],
+    }
+    
+    render(<RoomCard {...defaultProps} room={roomWithTags} />)
+    
+    expect(screen.getByText('Conference')).toBeInTheDocument()
+    expect(screen.getByText('Video Call')).toBeInTheDocument()
+    expect(screen.getByText('Large')).toBeInTheDocument()
+  })
+
+  it('should not render tags section when tags are not provided', () => {
+    const roomWithoutTags = {
+      ...mockRoom,
+      tags: undefined,
+    }
+    
+    render(<RoomCard {...defaultProps} room={roomWithoutTags} />)
+    
+    // Should still render the room card but not show any tag elements
+    expect(screen.getByText('Conference Room A')).toBeInTheDocument()
+    expect(screen.queryByText('Conference')).not.toBeInTheDocument()
+  })
+
+  it('should handle empty tags array', () => {
+    const roomWithEmptyTags = {
+      ...mockRoom,
+      tags: [],
+    }
+    
+    render(<RoomCard {...defaultProps} room={roomWithEmptyTags} />)
+    
+    // Should render the room card but not show any tag elements
+    expect(screen.getByText('Conference Room A')).toBeInTheDocument()
+    expect(screen.queryByText('Conference')).not.toBeInTheDocument()
+  })
 })

--- a/lib/__tests__/airtable.test.ts
+++ b/lib/__tests__/airtable.test.ts
@@ -69,7 +69,7 @@ describe('airtable', () => {
       const rooms = await getMeetingRooms();
 
       expect(fetchAllRecords).toHaveBeenCalledWith('MeetingRooms', {
-        fields: ['name', 'capacity', 'notes', 'location', 'status', 'startTime', 'endTime', 'image', 'maxMeetingHours'],
+        fields: ['name', 'capacity', 'notes', 'location', 'status', 'startTime', 'endTime', 'image', 'maxMeetingHours', 'tags'],
         sort: [{ field: 'name', direction: 'asc' }]
       });
 

--- a/lib/airtable.ts
+++ b/lib/airtable.ts
@@ -23,7 +23,7 @@ const MEETING_ROOMS_TABLE = env.AIRTABLE_MEETING_ROOMS_TABLE;
 const BOOKINGS_TABLE = env.AIRTABLE_BOOKINGS_TABLE;
 
 /** Array of public fields to retrieve for meeting rooms (excludes sensitive data) */
-const publicFieldsRooms = ['name', 'capacity', 'notes', 'location', 'status', 'startTime', 'endTime', 'image', 'maxMeetingHours'];
+const publicFieldsRooms = ['name', 'capacity', 'notes', 'location', 'status', 'startTime', 'endTime', 'image', 'maxMeetingHours', 'tags'];
 
 /**
  * Retrieves all meeting rooms from Airtable
@@ -389,6 +389,7 @@ function parseRoom(records: { id: string; fields: Record<string, unknown> }[]): 
     endTime: Number(record.fields.endTime || 64800), // 6:00 PM
     image: Array.isArray(record.fields.image) ? record.fields.image[0] : record.fields.image,
     maxMeetingHours: record.fields.maxMeetingHours ? Number(record.fields.maxMeetingHours) : undefined,
+    tags: Array.isArray(record.fields.tags) ? record.fields.tags as string[] : undefined,
   }));
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,6 +29,8 @@ export interface MeetingRoom {
   image: AirtableImage | null;
   /** Maximum number of hours a meeting can last in this room (optional - overrides global setting) */
   maxMeetingHours?: number;
+  /** Array of tags for grouping and categorizing rooms */
+  tags?: string[];
 }
 
 /**


### PR DESCRIPTION
## Description
Adds room tagging functionality to enable better categorization and organization of meeting rooms.

## Changes
- Added `tags` field to MeetingRoom interface and Airtable integration
- Enhanced RoomCard component to display tags as styled badges
- Updated README with setup instructions
- Added comprehensive test coverage

## Features
- Visual tag badges on room cards
- Airtable "Multiple Select" field integration
- Backward compatible with existing rooms
- Responsive design for all devices

## Setup
Add a "Multiple Select" field named `tags` to your Meeting Rooms table in Airtable and configure available options.

## Testing
All tests pass, including new tag-specific test cases.