### PR TITLE
fix: render upcoming meeting times in browser timezone

### DIFF
--- a/app/components/LocalTimeRange.tsx
+++ b/app/components/LocalTimeRange.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { formatSlotTime } from '@/utils/slots';
+
+interface LocalTimeRangeProps {
+  startTime: string;
+  endTime: string;
+}
+
+export function LocalTimeRange({ startTime, endTime }: LocalTimeRangeProps) {
+  return <span>{formatSlotTime(startTime)} - {formatSlotTime(endTime)}</span>;
+}

--- a/app/components/UpcomingMeetings.tsx
+++ b/app/components/UpcomingMeetings.tsx
@@ -7,8 +7,8 @@
 import { getMeetingRooms, getUpcomingBookings } from '@/lib/airtable';
 import { env } from '@/lib/env';
 import { Booking, MeetingRoom } from '@/lib/types';
-import { formatSlotTime } from '@/utils/slots';
 import { cache } from 'react';
+import { LocalTimeRange } from './LocalTimeRange';
 
 // Cache the getMeetingRooms function to avoid duplicate requests
 const getCachedMeetingRooms = cache(getMeetingRooms);
@@ -263,7 +263,7 @@ function MeetingItem({ booking, room, isCurrent }: MeetingItemProps) {
             <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
-            <span>{formatSlotTime(booking.startTime)} - {formatSlotTime(booking.endTime)}</span>
+            <LocalTimeRange startTime={booking.startTime} endTime={booking.endTime} />
           </div>
 
           <div className="flex items-center text-sm text-gray-600">


### PR DESCRIPTION
## Summary
- render the Upcoming Meetings sidebar time range in the browser timezone
- keep the sidebar data fetch server-side while moving only time formatting client-side

## Verification
- commit isolated on top of `main`
- attempted `npm test -- app/components/__tests__/UpcomingMeetings.test.tsx` in the clean worktree, but `jest` was not available there (`node_modules` missing)